### PR TITLE
Collections

### DIFF
--- a/django_webdav_storage/storage.py
+++ b/django_webdav_storage/storage.py
@@ -51,6 +51,9 @@ class WebDavStorage(StorageBase):
         return ContentFile(self.webdav('GET', name).content)
 
     def _save(self, name, content):
+        path_list = name.split('/')
+        for directory in path_list[:-1]:
+            self.requests.request('MKCOL', '{0}/{1}'.format(self.webdav_url, directory))
         self.webdav('PUT', name, data=content)
         return name
 

--- a/django_webdav_storage/storage.py
+++ b/django_webdav_storage/storage.py
@@ -52,8 +52,10 @@ class WebDavStorage(StorageBase):
 
     def _save(self, name, content):
         path_list = name.split('/')
+        coll_path = self.webdav_url
         for directory in path_list[:-1]:
-            self.requests.request('MKCOL', '{0}/{1}'.format(self.webdav_url, directory))
+            self.requests.request('MKCOL', '{0}/{1}'.format(coll_path,  directory))
+            coll_path += '/{}'.format(directory)
         self.webdav('PUT', name, data=content)
         return name
 


### PR DESCRIPTION
currently this cannot be done:

``` python
storage.save('somedir/somefile.txt', <file object>)
```

The webdav server returns `HTTPError: 403 Client Error: Forbidden`

This addition will create the `somedir` directory using the `MKCOL` verb so that `somefile.txt` can be saved in it.
