### PR TITLE
Use content.temporary_file_path or content.file for file reading

### DIFF
--- a/django_webdav_storage/storage.py
+++ b/django_webdav_storage/storage.py
@@ -59,7 +59,12 @@ class WebDavStorage(StorageBase):
                 self.webdav('MKCOL', '{0}/{1}'.format(coll_path,
                                                       directory))
                 coll_path += '/{}'.format(directory)
-        self.webdav('PUT', name, data=content)
+
+        if hasattr(content, 'temporary_file_path'):
+            with open(content.temporary_file_path(), 'rb') as f:
+                self.webdav('PUT', name, data=f)
+        else:
+            self.webdav('PUT', name, data=content.chunks())
         return name
 
     def delete(self, name):

--- a/django_webdav_storage/storage.py
+++ b/django_webdav_storage/storage.py
@@ -64,7 +64,8 @@ class WebDavStorage(StorageBase):
             with open(content.temporary_file_path(), 'rb') as f:
                 self.webdav('PUT', name, data=f)
         else:
-            self.webdav('PUT', name, data=content.chunks())
+            content.file.seek(0)
+            self.webdav('PUT', name, data=content.file)
         return name
 
     def delete(self, name):

--- a/django_webdav_storage/tests.py
+++ b/django_webdav_storage/tests.py
@@ -76,7 +76,7 @@ class TestSaveMethod(TestBase):
 
     def _make_memfile(self, filename, content):
         return InMemoryUploadedFile(
-            file=six.StringIO(content),
+            file=six.BytesIO(content),
             field_name='test_field',
             name='_save_new_file.txt',
             content_type='text/plain',
@@ -97,7 +97,7 @@ class TestSaveMethod(TestBase):
 
     def test_save_simplefile_ok(self):
         filename = self.session_id + '_save_new_file.txt'
-        content = 'test content one'
+        content = six.b('test content one')
 
         fileobj = self._make_simplefile(filename, content)
         self.storage.save(filename, fileobj)
@@ -106,7 +106,7 @@ class TestSaveMethod(TestBase):
 
     def test_save_simplefile_seeked_ok(self):
         filename = self.session_id + '_save_new_memsekfile.txt'
-        content = 'test content one'
+        content = six.b('test content one')
 
         fileobj = self._make_simplefile(filename, content)
         fileobj.seek(3)
@@ -117,7 +117,7 @@ class TestSaveMethod(TestBase):
 
     def test_save_memoryfile_ok(self):
         filename = self.session_id + '_save_new_file.txt'
-        content = 'test content one'
+        content = six.b('test content one')
 
         fileobj = self._make_memfile(filename, content)
         self.storage.save(filename, fileobj)
@@ -126,7 +126,7 @@ class TestSaveMethod(TestBase):
 
     def test_save_tempfile_ok(self):
         filename = self.session_id + '_save_new_file.txt'
-        content = 'test content'
+        content = six.b('test content')
         fileobj = self._make_tempfile(filename, content)
         self.storage.save(filename, fileobj)
 
@@ -135,7 +135,7 @@ class TestSaveMethod(TestBase):
 
     def test_save_memoryfile_seeked_ok(self):
         filename = self.session_id + '_save_new_file.txt'
-        content = 'test content one'
+        content = six.b('test content one')
 
         fileobj = self._make_memfile(filename, content)
         fileobj.seek(3)
@@ -146,7 +146,7 @@ class TestSaveMethod(TestBase):
 
     def test_save_tempfile_seeked_ok(self):
         filename = self.session_id + '_save_new_file.txt'
-        content = 'test content'
+        content = six.b('test content')
         fileobj = self._make_tempfile(filename, content)
         fileobj.seek(4)
 

--- a/django_webdav_storage/tests.py
+++ b/django_webdav_storage/tests.py
@@ -4,10 +4,14 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
+import tempfile
 from django import test
 from django.core.files.base import ContentFile
 from django_webdav_storage.storage import WebDavStorage
 from django.utils import six
+from django.core.files.uploadedfile import (
+    InMemoryUploadedFile, TemporaryUploadedFile,
+)
 import uuid
 import os
 
@@ -60,6 +64,96 @@ class TestOverrideSettings(object):
         with self.settings(**{self.setting: value}):
             self.assertEquals(first=value,
                               second=getattr(self.storage, self.method)())
+
+
+class TestSaveMethod(TestBase):
+
+    def _make_simplefile(self, filename, content):
+        fileobj = tempfile.NamedTemporaryFile()
+        fileobj.write(content)
+        fileobj.flush()
+        return fileobj
+
+    def _make_memfile(self, filename, content):
+        return InMemoryUploadedFile(
+            file=six.StringIO(content),
+            field_name='test_field',
+            name='_save_new_file.txt',
+            content_type='text/plain',
+            size=0,
+            charset='utf8',
+        )
+
+    def _make_tempfile(self, filename, content):
+        fileobj = TemporaryUploadedFile(
+            name=filename + ".tempfile",
+            content_type='text/plain',
+            size=0,
+            charset='utf8',
+        )
+        fileobj.write(content)
+        fileobj.flush()
+        return fileobj
+
+    def test_save_simplefile_ok(self):
+        filename = self.session_id + '_save_new_file.txt'
+        content = 'test content one'
+
+        fileobj = self._make_simplefile(filename, content)
+        self.storage.save(filename, fileobj)
+        with self.storage.open(filename) as f:
+            self.assertEqual(f.read(), content)
+
+    def test_save_simplefile_seeked_ok(self):
+        filename = self.session_id + '_save_new_memsekfile.txt'
+        content = 'test content one'
+
+        fileobj = self._make_simplefile(filename, content)
+        fileobj.seek(3)
+
+        self.storage.save(filename, fileobj)
+        with self.storage.open(filename) as f:
+            self.assertEqual(f.read(), content)
+
+    def test_save_memoryfile_ok(self):
+        filename = self.session_id + '_save_new_file.txt'
+        content = 'test content one'
+
+        fileobj = self._make_memfile(filename, content)
+        self.storage.save(filename, fileobj)
+        with self.storage.open(filename) as f:
+            self.assertEqual(f.read(), content)
+
+    def test_save_tempfile_ok(self):
+        filename = self.session_id + '_save_new_file.txt'
+        content = 'test content'
+        fileobj = self._make_tempfile(filename, content)
+        self.storage.save(filename, fileobj)
+
+        with self.storage.open(filename) as f:
+            self.assertEqual(f.read(), content)
+
+    def test_save_memoryfile_seeked_ok(self):
+        filename = self.session_id + '_save_new_file.txt'
+        content = 'test content one'
+
+        fileobj = self._make_memfile(filename, content)
+        fileobj.seek(3)
+
+        self.storage.save(filename, fileobj)
+        with self.storage.open(filename) as f:
+            self.assertEqual(f.read(), content)
+
+    def test_save_tempfile_seeked_ok(self):
+        filename = self.session_id + '_save_new_file.txt'
+        content = 'test content'
+        fileobj = self._make_tempfile(filename, content)
+        fileobj.seek(4)
+
+        self.storage.save(filename, fileobj)
+
+        with self.storage.open(filename) as f:
+            self.assertEqual(f.read(), content)
 
 
 class TestExistsMethod(TestBase):

--- a/webdav.conf
+++ b/webdav.conf
@@ -10,6 +10,7 @@ server {
 
         dav_methods             PUT DELETE MKCOL COPY MOVE;
         dav_access              user:rw   group:r   all:r;
+        client_body_timeout     5s;
 
         limit_except GET {
             allow                   127.0.0.1/32;


### PR DESCRIPTION
Hello!

I use django-ckeditor library, which validates uploaded image before saving:
https://github.com/django-ckeditor/django-ckeditor/blob/master/ckeditor/views.py#L49

For image validation pillow reads first bytes of uploaded file and doesn't seek cursor position back to previous value:
https://github.com/django-ckeditor/django-ckeditor/blob/master/ckeditor/image/pillow_backend.py

This resulting to the wrong content to be sent to the webdav server.
Django default filesystem storage saves files correctly,because it uses content.chunks (which seek filepos to zero) or just moves temporary file to the persistent storage:
https://github.com/django/django/blob/master/django/core/files/storage.py#L253
https://github.com/django/django/blob/master/django/core/files/uploadedfile.py#L100
https://github.com/django/django/blob/master/django/core/files/storage.py#L240

Maybe django-webdav-storage should behave the same?
