### PR TITLE
dedicated WEBDAV_BASIC_AUTH settings

### DIFF
--- a/django_webdav_storage/storage.py
+++ b/django_webdav_storage/storage.py
@@ -18,6 +18,7 @@ class WebDavStorage(StorageBase):
         self.public_url = self.set_public_url(**kwargs)
         self.listing_backend = kwargs.get('listinb_backend') or \
             setting('WEBDAV_LISTING_BACKEND')
+        self.basic_auth = setting('WEBDAV_BASIC_AUTH')
 
         if not self.webdav_url:
             raise NotImplementedError('Please define webdav url')
@@ -58,6 +59,10 @@ class WebDavStorage(StorageBase):
     def webdav(self, method, name, *args, **kwargs):
         url = self.get_webdav_url(name)
         method = method.lower()
+        if self.basic_auth:
+            if not kwargs:
+                kwargs = {}
+            kwargs["auth"] = (self.basic_auth["user"], self.basic_auth["password"])
         response = getattr(self.requests, method)(url, *args, **kwargs)
         response.raise_for_status()
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -21,6 +21,16 @@ If you want use HTTP Basic authorization to WebDAV access, you can specify your 
     WEBDAV_URL = 'http://johndoe:secret@my-internal-webdav-server.example.com'
 
 
+Alternatively, if you want to avoid having the password written to log files in case of errors, you can specify authentication settings like this:
+
+.. code:: python
+
+    WEBDAV_BASIC_AUTH = {
+        "user": "dav_user",
+        "password": "secret123456",
+    }
+
+
 Second, set the ``django_webdav_storage.storage.WebDavStorage`` storage class as default storage class:
 
 .. code:: python


### PR DESCRIPTION
Thanks for django-webdav-storage. This pull request adds a dedicated WEBDAV_BASIC_AUTH configuration setting. I did not like having to add a password to the URL, since this might be written to logs; it is written to stderr when testing on the console and the URL cannot be resolved, for example.

It passes the credentials to the 'auth' kwarg of requests.